### PR TITLE
added missing jquery dep causing startup bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "extract-zip": "^1.6.7",
     "get-port": "^5.0.0",
     "get-uri": "^2.0.3",
+    "jquery": "^3.4.1",
     "menubar": "^6.0.7",
     "mustache": "^3.0.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
after doing `npm install` then `npm start` the loading screen got stuck. Opening up the developer tools showed me there was an error on the line below, that it couldn't find jquery

Because of this in `splash.html`:
```html
<script> window.$ = window.jQuery = require('jquery'); </script>
```

3.3.1 had a security issue, so I ran `npm audit fix` to bump to 3.4.1 
