### PR TITLE
Fix memory leak

### DIFF
--- a/holoscape.js
+++ b/holoscape.js
@@ -300,6 +300,9 @@ class Holoscape {
         if(level == 'error') console.error(message)
         else console.log(message)
         global.holoscape.logMessages.push({level, message})
+        while(global.holoscape.logMessages.length > 100) {
+          global.holoscape.logMessages.shift()
+        }
         if(global.holoscape.logWindow && global.holoscape.logWindow.webContents) {
           global.holoscape.logWindow.webContents.send('log', {level,message})
         }

--- a/initial_conductor_config.toml
+++ b/initial_conductor_config.toml
@@ -17,7 +17,7 @@ instances = []
 
 [logger]
 type = "debug"
-state_dump = true
+state_dump = false
 
 {{{networkConfigToml}}}
 

--- a/views/conductor_log.html
+++ b/views/conductor_log.html
@@ -41,6 +41,9 @@
         let {level, message} = store
         message = convert.toHtml(message)
         app.logs.push({level, message})
+        while(app.logs.length > 100) {
+            app.logs.shift()
+          }
       });
 
     </script>

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -341,7 +341,11 @@
                     return
                 }
 
-                app.reduxActions[instance_id].push(signal.action)
+                let actions = app.reduxActions[instance_id]
+                actions.push(signal.action)
+                while(actions.lenght > 100) {
+                    actions.shift()
+                }
             })
 
             refresh()

--- a/views/splash.html
+++ b/views/splash.html
@@ -247,9 +247,12 @@
        })
 
        ipcRenderer.on('log', (event,store) => {
-           let {level, message} = store
-           message = convert.toHtml(message)
-           app.logs.push({level, message})
+          let {level, message} = store
+          message = convert.toHtml(message)
+          app.logs.push({level, message})
+          while(app.logs.length > 20) {
+            app.logs.shift()
+          }
        });
 
        ipcRenderer.on('splash-status', (event, message) => {


### PR DESCRIPTION
Holoscape was keeping all conductor logs in memory, three times. With state dump enabled this would grow up to several GBs over the course of a few hours.

Here we are keeping a maximum of 100 last log messages.

Follow up:
make this a configuration setting