### PR TITLE
Fix CMD+Q on macOS

### DIFF
--- a/holoscape.js
+++ b/holoscape.js
@@ -286,7 +286,7 @@ class Holoscape {
         { type: 'separator' },
         { label: 'Install hApp...', click: ()=>this.installBundleWindow.show() },
         { type: 'separator' },
-        { label: 'Quit', click: ()=>{this.shutdownConductor(); this.quitting=true; mb.app.quit()} }
+        { label: 'Quit', click: ()=> this.quit() }
       ])
       mb.tray.setToolTip('HoloScape')
       mb.tray.setContextMenu(contextMenu)
@@ -398,6 +398,12 @@ class Holoscape {
         console.error('Holoscape could not connect to conductor', error)
         global.holoscape.checkConductorConnection()
       })
+    }
+
+    quit() {
+      this.shutdownConductor()
+      this.quitting=true
+      mb.app.quit()
     }
   }
 

--- a/main.js
+++ b/main.js
@@ -46,6 +46,12 @@ app.on('window-all-closed', e => {
   if(!global.holoscape.quitting) e.preventDefault()
 })
 
+app.on('before-quit', e => {
+  if(!global.holoscape.quitting) {
+    global.holoscape.quit()
+  }
+})
+
 mb.on('ready', async () => {
   mb.tray.setImage(systemTrayIconEmpty())
   global.holoscape = new Holoscape()


### PR DESCRIPTION
On macOS it is possible and common behaviour to quit apps via the main menu or CMD+Q. This would lead to several errors as it doesn't trigger the intended code path.

This PR fixes that and therefore closes https://github.com/holochain/holoscape/issues/30.