### PR TITLE
Make debug view fast and really usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ hc-darwin
 .DS_Store
 Holoscape-linux-x64
 Holoscape-darwin-x64
+
+views/debug_view.dist.js

--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,7 @@ with holonix.pkgs;
   ln -sf ${holonix.holochain.holochain}/bin/holochain holochain-${target-os}
   ln -sf ${holonix.holochain.hc}/bin/hc hc-${target-os}
   ${holonix.pkgs.nodejs}/bin/npm install
+  ${holonix.pkgs.nodejs}/bin/npx webpack
   export PATH="$PATH:$( ${holonix.pkgs.nodejs}/bin/npm bin )"
   ''
   holonix.shell.shellHook

--- a/holoscape.js
+++ b/holoscape.js
@@ -377,7 +377,7 @@ class Holoscape {
           if(this.quitting) return
           this.debuggerWindow.webContents.send('hc-signal', params)
           //console.log(JSON.stringify(params))
-          if (params.signal.name === 'switch_view') {
+          if (params.signal && params.signal.name === 'switch_view') {
             const { view, location } = JSON.parse(params.signal.arguments)
             console.log('Open ' + view + ' for ' + location)
             this.happUiController.showAndRiseUI(view, `${location}`)

--- a/package.json
+++ b/package.json
@@ -12,10 +12,20 @@
     "delete:app-support": "rm -rf '$HOME/Library/Application Support/holoscape' && rm -rf '$HOME/Library/Application Support/Holoscape-default'"
   },
   "author": "Holochain Core Dev Team <devcore@holochain.org>",
-  "license": "GPLv3",
+  "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "deepmerge": "^4.2.2",
     "electron": "^6.0.0",
-    "electron-packager": "^14.0.4"
+    "electron-packager": "^14.0.4",
+    "electron-webpack": "^2.7.4",
+    "fibers": "^4.0.2",
+    "sass": "^1.23.7",
+    "sass-loader": "^8.0.0",
+    "vue-loader": "^15.7.2",
+    "vue-style-loader": "^4.1.2",
+    "vuetify-loader": "^1.4.3",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10"
   },
   "dependencies": {
     "@holochain/hc-web-client": "^0.5.0",
@@ -34,7 +44,8 @@
     "temp": "^0.9.0",
     "toml": "^3.0.0",
     "vue": "^2.6.10",
-    "vue-chat-scroll": "^1.3.6"
+    "vue-chat-scroll": "^1.3.6",
+    "vuetify": "^2.1.13"
   },
   "build": {
     "appId": "org.holochain.holoscape",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "@holochain/hc-web-client": "^0.5.0",
+    "@holochain/hc-web-client": "^0.5.1",
     "@iarna/toml": "^2.2.3",
     "ansi-to-html": "^0.6.11",
     "bootstrap": "^4.3.1",

--- a/views/common.css
+++ b/views/common.css
@@ -1,7 +1,10 @@
 body {
     background: linear-gradient(45deg, #1a0231f2, #00017f);
-    color: white;
     padding-top: 40px;
+}
+
+h1 {
+    color: white;
 }
 
 h2, h3, h4 {

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -98,13 +98,14 @@
                         caption="Source Chain"
                         :headers="chainHeaders"
                     :items="dump.source_chain"
-                    :search="chainSearch"
-                    show-expand
-                    class="elevation-1"
-                    item-key="entry_address"
-                >
-                    <template v-slot:top>
-                        <v-toolbar flat>
+                        :search="chainSearch"
+                        show-expand
+                        class="elevation-1"
+                        item-key="entry_address"
+                        disable-sort
+                    >
+                        <template v-slot:top>
+                            <v-toolbar flat>
                             <v-text-field
                             v-model="chainSearch"
                             append-icon="search"
@@ -147,19 +148,40 @@
                             </tbody>
                         </table>
                         <h4>Held entries:</h4>
-                        <ul class="black">
-                            <li v-for="(aspects, address) in dump.held_aspects">
-                                <ul>
-                                    <li>{{ address }}</li>
-                                    <li><div class="alert alert-dark" :class="{clickFetch: contents[address]==undefined}" v-on:click="updateContent(address, instance_id)" role="alert">{{ contents[address] ? contents[address].type : 'get type' }}</div></li>
-                                    <li><div class="alert alert-dark" :class="{clickFetch: contents[address]==undefined}" v-on:click="updateContent(address, instance_id)" role="alert">{{ contents[address] ? contents[address].content : 'get content' }}</div></li>
-                                </ul>
-                                <td></td>
-                                
-                                
-                                <td>{{aspects}}</td>
-                            </li>
-                        </ul>
+                        <v-data-table
+                            :headers="heldHeaders"
+                            :items="Object.keys(dump.held_aspects).map((address) => {
+                                return {address, aspects: dump.held_aspects[address]};
+                              })"
+                            :search="heldSearch"
+                            show-expand
+                            class="elevation-1"
+                            item-key="address"
+                            disable-sort
+                        >
+                            <template v-slot:top>
+                                <v-toolbar flat>
+                                    <v-text-field
+                                    v-model="heldSearch"
+                                    append-icon="search"
+                                    label="Search"
+                                    single-line
+                                    hide-details
+                                    ></v-text-field>
+                                </v-toolbar>
+                            </template>
+                            <template v-slot:item.type="{ item }">
+                                    <div :class="{clickFetch: contents[item.address]==undefined}" v-on:click="updateContent(item.address, instance_id)" role="alert">{{ contents[item.address] ? contents[item.address].type : 'get type' }}</div>
+                            </template>
+                            <template v-slot:item.content="{ item }">
+                                    <div :class="{clickFetch: contents[item.address]==undefined}" v-on:click="updateContent(item.address, instance_id)" role="alert">{{ contents[item.address] ? contents[item.address].content : 'get content' }}</div>
+                            </template>
+                            <template v-slot:expanded-item="{ headers, item }">
+                                <td :colspan="headers.length">
+                                    {{ item.aspects }}
+                                </td>
+                            </template>
+                        </v-data-table>
                 </div>
             </li>
             <li class="list-group-item">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -120,7 +120,7 @@
                             <v-chip v-if="typeof item.entry_type == 'object'" color="teal" >{{ item.entry_type['App'] }}</v-chip>
                         </template>
                         <template v-slot:item.provenances="{ item }">
-                            <span>{{ item.provenances.map((p)=>p[0]) }}</span>
+                            <span>{{ item.provenances.map((p)=>p[0]).join(', ') }}</span>
                     </template>
                     <template v-slot:expanded-item="{ headers, item }">
                         <td :colspan="headers.length">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -105,7 +105,6 @@
                             <v-toolbar flat>
                                 <v-text-field
                                 v-model="chainSearch"
-                                append-icon="search"
                                 label="Search"
                                 single-line
                                 hide-details
@@ -156,7 +155,6 @@
                                 <v-toolbar flat>
                                     <v-text-field
                                     v-model="queueSearch"
-                                    append-icon="search"
                                     label="Search"
                                     single-line
                                     hide-details
@@ -189,7 +187,6 @@
                                 <v-toolbar flat>
                                     <v-text-field
                                     v-model="heldSearch"
-                                    append-icon="search"
                                     label="Search"
                                     single-line
                                     hide-details

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -42,6 +42,12 @@
           word-wrap: break-word;
           overflow: scroll;
       }
+      .light-blue-background {
+          background: lightblue !important;
+      }
+      .light-green-background {
+          background: lightgreen !important;
+      }
     </style>
   </head>
   <body>
@@ -116,8 +122,8 @@
                             </v-toolbar>
                         </template>
                         <template v-slot:item.entry_type="{ item }">
-                            <v-chip v-if="typeof item.entry_type == 'string'" color="blue" >{{ item.entry_type }}</v-chip>
-                            <v-chip v-if="typeof item.entry_type == 'object'" color="teal" >{{ item.entry_type['App'] }}</v-chip>
+                            <v-chip v-if="typeof item.entry_type == 'string'" class="light-blue-background" >{{ item.entry_type }}</v-chip>
+                            <v-chip v-if="typeof item.entry_type == 'object'" class="light-green-background" >{{ item.entry_type['App'] }}</v-chip>
                         </template>
                         <template v-slot:item.provenances="{ item }">
                             <span>{{ item.provenances.map((p)=>p[0]).join(', ') }}</span>

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -93,10 +93,37 @@
                     </a>
                 </h3>
                 <v-data-table
+                    caption="Source Chain"
                     :headers="chainHeaders"
                     :items="dump.source_chain"
                     :search="chainSearch"
+                    show-expand
+                    class="elevation-1"
+                    item-key="entry_address"
                 >
+                    <template v-slot:top>
+                        <v-toolbar flat>
+                            <v-text-field
+                            v-model="chainSearch"
+                            append-icon="search"
+                            label="Search"
+                            single-line
+                            hide-details
+                            ></v-text-field>
+                        </v-toolbar>
+                    </template>
+                    <template v-slot:item.entry_type="{ item }">
+                        <v-chip v-if="typeof item.entry_type == 'string'" color="light-blue" >{{ item.entry_type }}</v-chip>
+                        <v-chip v-if="typeof item.entry_type == 'object'" color="green" >{{ item.entry_type['App'] }}</v-chip>
+                    </template>
+                    <template v-slot:item.provenances="{ item }">
+                        <span>{{ item.provenances.map((p)=>p[0]) }}</span>
+                    </template>
+                    <template v-slot:expanded-item="{ headers, item }">
+                        <td :colspan="headers.length">
+                            <div :class="{clickFetch: contents[item.entry_address]==undefined}" v-on:click="updateContent(item.entry_address, instance_id)">{{ contents[item.entry_address] ? contents[item.entry_address].content : 'click to fetch' }}</div>
+                        </td>
+                    </template>
                 </v-data-table>
                 <div v-bind:id="sanitizeName(instance_id)+'-source-chain'" class="card collapse" v-for="header in dump.source_chain">
                     <div class="card-body">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -61,10 +61,10 @@
             </a>
         </h2>
         <button class="btn btn-primary" v-on:click="updateStateDump(instance_id)">Update state dump</button>
-        <input type="checkbox" v-bind:id="sanitizeName(instance_id)-dump-check" v-model="refreshDump[instance_id]">
-        <label for="sanitizeName(instance_id)-dump-check">Live refresh</label>
-        <input type="checkbox" v-bind:id="sanitizeName(instance_id)-actions-check" v-model="updateActions[instance_id]">
-        <label for="sanitizeName(instance_id)-actions-check">Update actions</label>
+        <input type="checkbox" v-bind:id="sanitizeName(instance_id)+'-dump-check'" v-model="refreshDump[instance_id]">
+        <label v-bind:for="sanitizeName(instance_id)+'-dump-check'">Live refresh</label>
+        <input type="checkbox" v-bind:id="sanitizeName(instance_id)+'-actions-check'" v-model="updateActions[instance_id]">
+        <label v-bind:for="sanitizeName(instance_id)+'-actions-check'">Update actions</label>
                 
 
         <ul class="list-group collapse" v-bind:id="sanitizeName(instance_id)">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -92,9 +92,11 @@
                         Source Chain
                     </a>
                 </h3>
-                <v-data-table
-                    caption="Source Chain"
-                    :headers="chainHeaders"
+
+                <div v-bind:id="sanitizeName(instance_id)+'-source-chain'" class="card collapse">
+                    <v-data-table
+                        caption="Source Chain"
+                        :headers="chainHeaders"
                     :items="dump.source_chain"
                     :search="chainSearch"
                     show-expand
@@ -110,34 +112,21 @@
                             single-line
                             hide-details
                             ></v-text-field>
-                        </v-toolbar>
-                    </template>
-                    <template v-slot:item.entry_type="{ item }">
-                        <v-chip v-if="typeof item.entry_type == 'string'" color="light-blue" >{{ item.entry_type }}</v-chip>
-                        <v-chip v-if="typeof item.entry_type == 'object'" color="green" >{{ item.entry_type['App'] }}</v-chip>
-                    </template>
-                    <template v-slot:item.provenances="{ item }">
-                        <span>{{ item.provenances.map((p)=>p[0]) }}</span>
+                            </v-toolbar>
+                        </template>
+                        <template v-slot:item.entry_type="{ item }">
+                            <v-chip v-if="typeof item.entry_type == 'string'" color="blue" >{{ item.entry_type }}</v-chip>
+                            <v-chip v-if="typeof item.entry_type == 'object'" color="teal" >{{ item.entry_type['App'] }}</v-chip>
+                        </template>
+                        <template v-slot:item.provenances="{ item }">
+                            <span>{{ item.provenances.map((p)=>p[0]) }}</span>
                     </template>
                     <template v-slot:expanded-item="{ headers, item }">
                         <td :colspan="headers.length">
                             <div :class="{clickFetch: contents[item.entry_address]==undefined}" v-on:click="updateContent(item.entry_address, instance_id)">{{ contents[item.entry_address] ? contents[item.entry_address].content : 'click to fetch' }}</div>
-                        </td>
-                    </template>
-                </v-data-table>
-                <div v-bind:id="sanitizeName(instance_id)+'-source-chain'" class="card collapse" v-for="header in dump.source_chain">
-                    <div class="card-body">
-                        <h5 class="card-title">{{header.entry_type}} - {{header.entry_address}}</h5>
-                        <table class="table">
-                            <tbody>
-                                <tr><td>Timestamp:</td><td>{{ header.timestamp }}</td></tr>
-                                <tr><td>Sources:</td><td>{{ header.provenances.map((p)=>p[0]).join(", ") }}</td></tr>
-                                <tr><td>Entry address:</td><td>{{ header.entry_address }}</td></tr>
-                                <tr><td>Prev. header:</td><td>{{ header.link }}</td></tr>
-                            </tbody>
-                        </table>
-                        <div class="alert alert-dark" role="alert" :class="{clickFetch: contents[header.entry_address]==undefined}" v-on:click="updateContent(header.entry_address, instance_id)">{{ contents[header.entry_address] ? contents[header.entry_address].content : 'click to fetch' }}</div>
-                    </div>
+                            </td>
+                        </template>
+                    </v-data-table>
                 </div>
             </li>
             <li class="list-group-item">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -5,7 +5,9 @@
     <script>require('popper.js');</script>
     <script>require('bootstrap');</script>
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
-<link rel="stylesheet" href="common.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="common.css">
     <style>
       .error {
         color: red;

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -2,7 +2,6 @@
   <head>
     <title>Holoscape instance debug view</title>
     <script>window.$ = window.jQuery = require('jquery');</script>
-    <script>const Vue = require('vue/dist/vue.common');</script>
     <script>require('popper.js');</script>
     <script>require('bootstrap');</script>
     <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
@@ -91,6 +90,12 @@
                         Source Chain
                     </a>
                 </h3>
+                <v-data-table
+                    :headers="chainHeaders"
+                    :items="dump.source_chain"
+                    :search="chainSearch"
+                >
+                </v-data-table>
                 <div v-bind:id="sanitizeName(instance_id)+'-source-chain'" class="card collapse" v-for="header in dump.source_chain">
                     <div class="card-body">
                         <h5 class="card-title">{{header.entry_type}} - {{header.entry_address}}</h5>
@@ -194,165 +199,7 @@
       <button type="button" class="btn btn-primary" v-on:click="refresh()">Refresh instances</button>
     </div>
 
-    <script>
-        const { ipcRenderer } = require('electron')
-        const VueChatScroll = require('vue-chat-scroll')
-        Vue.use(VueChatScroll)
-        
-        let configured = false
-
-        ipcRenderer.on('conductor-call-set', () => {
-            if(configured) return
-            configured = true
-
-            const remote = require('electron').remote
-            const happUiController = remote.getGlobal('holoscape').happUiController
-            const call = remote.getGlobal('conductor_call')
-
-            const refresh = () => {
-              call('debug/running_instances')().then((instances)=>{
-                  instances.map((instance_id) => {
-                      app.updateStateDump(instance_id)
-                      Vue.set(app.updateActions, instance_id, false)
-                      Vue.set(app.refreshDump, instance_id, false)
-                      app.instances.push(instance_id)
-                    })
-                })
-            }
-
-            setInterval(() => {
-                for(let instance of app.instances) {
-                    if(app.refreshDump[instance]) {
-                        app.updateStateDump(instance)
-                    }
-                }
-            }, 1500)
-
-            const fetch_cas = async (address, instance_id) => {
-                return await call('debug/fetch_cas')({instance_id, address})
-            }
-
-            const updateContent = async (address, instance_id) => {
-                Vue.set(app.contents, address, await fetch_cas(address, instance_id))
-            }
-
-            const syntaxHighlight = (json) => {
-                if (typeof json != 'string') {
-                    json = JSON.stringify(json, undefined, 2);
-                }
-                json = json.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
-                    var cls = 'number';
-                    if (/^"/.test(match)) {
-                        if (/:$/.test(match)) {
-                            cls = 'key';
-                        } else {
-                            cls = 'string';
-                        }
-                    } else if (/true|false/.test(match)) {
-                        cls = 'boolean';
-                    } else if (/null/.test(match)) {
-                        cls = 'null';
-                    }
-                    return '<span class="' + cls + '">' + match + '</span>';
-                });
-            }
-
-            var app = new Vue({
-                el: '#app',
-                data: {
-                  instances: [],  
-                  reduxActions: {},  
-                  stateDumps: {},
-                  refreshDump: {},
-                  contents: {},
-                  updateActions: {},
-                  updateStateDump: (instance_id) => {
-                      console.log(`Update state dump with: ${instance_id}`)
-                      call('debug/state_dump')({instance_id})
-                        .then((dump) => {
-                            console.log("Got state dump: ", dump)
-                            Vue.set(app.stateDumps, instance_id, dump)
-                        })
-                        .catch((error) => {
-                            console.log("Error getting dump:", error)
-                        })
-                  },
-                  refresh: refresh,
-                  fetch_cas,
-                  updateContent,
-                  syntaxHighlight,
-                  actionTypeToBadge: (actionType) => {
-                      switch(actionType) {
-                          case "SignalZomeFunctionCall": return "info"
-                          case "ReturnZomeFunctionResult": return "info"
-                          case "ReturnValidationPackage": return "secondary"
-                          case "ReturnValidationResult": return "secondary"
-                          case "Commit": return "success"
-                          case "Publish": return "success"
-                          case "HoldAspect": return "danger"
-                          case "Query": return "light"
-                          case "RespondQuery": return "dark"
-                          case "HandleQuery": return "light"
-                          case "QueryTimeout": return "warning"
-                          default: return "primary"
-                      }
-                  },
-                  sanitizeName: (name) => {
-                    name = name
-                        .split('_').join('-')
-                        .split(' ').join('-')
-                        .split('&').join('-')
-                        .split('#').join('-')
-                        .split('.').join('-')
-                        .split('$').join('-')
-                        .toLowerCase()
-                    return name
-                  },
-                  showAction: (action) => {
-                      window.alert(JSON.stringify(action))
-                  }
-                }
-            })
-
-            ipcRenderer.on('hc-signal', (event, params) => {
-                let { signal, instance_id } = params
-                if(!signal) {
-                    console.log("Got strange signal without 'signal' property:", params)
-                    return
-                }
-                if(!instance_id) {
-                    console.log("Got strange signal without 'instance_id' property:", params)
-                    return
-                }
-
-                if(signal.signal_type != "Trace") {
-                    // Ignoring non-trace signals
-                    return
-                }
-                if(!app.reduxActions[instance_id]) {
-                    Vue.set(app.reduxActions, instance_id, [])
-                }
-                if(!app.updateActions[instance_id]) {
-                    return
-                }
-                if(!signal.action) {
-                    console.log("Got strange trace signal without 'action' property:", params)
-                    return
-                }
-
-                let actions = app.reduxActions[instance_id]
-                actions.push(signal.action)
-                while(actions.lenght > 100) {
-                    actions.shift()
-                }
-            })
-
-            refresh()
-            window.app = app
-            window.call = call
-        })
-    </script>
+    <script type="text/javascript" src="debug_view.dist.js"></script>
 
 
 

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -54,12 +54,6 @@
 
     <div id="app" class="container">
       <h1> Holoscape instance debug view</h1>
-      <!--
-      <div><span>DNAs:</span><span>{{ dnas }}</span></div>
-      <div><span>Instances:</span><span>{{ instances }}</span></div>
-      <div><span>Interfaces:</span><span>{{ interfaces }}</span></div>
-      <div><span>agents:</span><span>{{ agents }}</span></div>
-      -->
       <ul class="list-group">
       <li class="list-group-item" v-for="instance_id in instances">
         <h2>
@@ -67,6 +61,9 @@
                 {{ instance_id }}
             </a>
         </h2>
+        <div>Holding entries/aspects: <span class="badge badge-primary">{{stats[instance_id].number_held_entries}}/{{stats[instance_id].number_held_aspects}}</span></div>
+        <div>Pending validations: <span class="badge badge-primary">{{stats[instance_id].number_pending_validations}}</span></div>
+        <div>Running zome calls: <span class="badge badge-primary">{{stats[instance_id].number_running_zome_calls}}</span></div>
 
         <ul class="list-group collapse" v-bind:id="sanitizeName(instance_id)">
             <li class="list-group-item">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -138,15 +138,44 @@
                 </h3>
                 <div class="collapse" v-bind:id="sanitizeName(instance_id)+'-dht'">
                         <h4>Validation queue:</h4>
-                        <table class="table">
-                            <tbody>
-                                <tr v-for="validation in dump.queued_holding_workflows">
-                                    <td>{{validation[0].workflow}}</td>
-                                    <td>{{validation[1]}}</td>
-                                    <td>{{validation[0].entry_with_header}}</td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <v-data-table
+                            :headers="queueHeaders"
+                            :items="Object.keys(dump.queued_holding_workflows).map((i) => {
+                                return {
+                                    address: i.pending.entry_with_header.header.entry_address,
+                                    workflow: i.pending.workflow,
+                                    dependencies: i.pending.dependencies,
+                                    entry_with_header: i.pending.entry_with_header,
+                                    timeout: i.timeout
+                                };
+                            })"
+                            :search="queueSearch"
+                            show-expand
+                            class="elevation-1"
+                            item-key="address"
+                            disable-sort
+                        >
+                            <template v-slot:top>
+                                <v-toolbar flat>
+                                    <v-text-field
+                                    v-model="queueSearch"
+                                    append-icon="search"
+                                    label="Search"
+                                    single-line
+                                    hide-details
+                                    ></v-text-field>
+                                </v-toolbar>
+                            </template>
+                            <template v-slot:item.timeout="{ item }">
+                                    <span v-if="item.timeout">{{item.timeout.delay}}</span>
+                                    <span v-if="!item.timeout">n/a</span>
+                            </template>
+                            <template v-slot:expanded-item="{ headers, item }">
+                                <td :colspan="headers.length">
+                                    {{ item.entry_with_header }}
+                                </td>
+                            </template>
+                        </v-data-table>
                         <h4>Held entries:</h4>
                         <v-data-table
                             :headers="heldHeaders"

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -67,12 +67,6 @@
                 {{ instance_id }}
             </a>
         </h2>
-        <button class="btn btn-primary" v-on:click="updateStateDump(instance_id)">Update state dump</button>
-        <input type="checkbox" v-bind:id="sanitizeName(instance_id)+'-dump-check'" v-model="refreshDump[instance_id]">
-        <label v-bind:for="sanitizeName(instance_id)+'-dump-check'">Live refresh</label>
-        <input type="checkbox" v-bind:id="sanitizeName(instance_id)+'-actions-check'" v-model="updateActions[instance_id]">
-        <label v-bind:for="sanitizeName(instance_id)+'-actions-check'">Update actions</label>
-                
 
         <ul class="list-group collapse" v-bind:id="sanitizeName(instance_id)">
             <li class="list-group-item">

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -61,7 +61,7 @@
       <div><span>agents:</span><span>{{ agents }}</span></div>
       -->
       <ul class="list-group">
-      <li class="list-group-item" v-for="(dump, instance_id, index) in stateDumps">
+      <li class="list-group-item" v-for="instance_id in instances">
         <h2>
             <a data-toggle="collapse" v-bind:href="'#'+sanitizeName(instance_id)" role="button" aria-expanded="false" v-bind:aria-controls="sanitizeName(instance_id)">
                 {{ instance_id }}
@@ -103,7 +103,7 @@
                     <v-data-table
                         caption="Source Chain"
                         :headers="chainHeaders"
-                        :items="dump.source_chain"
+                        :items="sourceChains[instance_id]"
                         :search="chainSearch"
                         show-expand
                         class="elevation-1"
@@ -112,13 +112,13 @@
                     >
                         <template v-slot:top>
                             <v-toolbar flat>
-                            <v-text-field
-                            v-model="chainSearch"
-                            append-icon="search"
-                            label="Search"
-                            single-line
-                            hide-details
-                            ></v-text-field>
+                                <v-text-field
+                                v-model="chainSearch"
+                                append-icon="search"
+                                label="Search"
+                                single-line
+                                hide-details
+                                ></v-text-field>
                             </v-toolbar>
                         </template>
                         <template v-slot:item.entry_type="{ item }">
@@ -146,7 +146,7 @@
                         <h4>Validation queue:</h4>
                         <v-data-table
                             :headers="queueHeaders"
-                            :items="Object.keys(dump.queued_holding_workflows).map((i) => {
+                            :items="Object.keys(validationQueues[instance_id]).map((i) => {
                                 return {
                                     address: i.pending.entry_with_header.header.entry_address,
                                     workflow: i.pending.workflow,
@@ -185,8 +185,8 @@
                         <h4>Held entries:</h4>
                         <v-data-table
                             :headers="heldHeaders"
-                            :items="Object.keys(dump.held_aspects).map((address) => {
-                                return {address, aspects: dump.held_aspects[address]};
+                            :items="Object.keys(holdingMaps[instance_id]).map((address) => {
+                                return {address, aspects: holdingMaps[instance_id][address]};
                               })"
                             :search="heldSearch"
                             show-expand
@@ -230,7 +230,7 @@
                         <tr>
                             <td>Queued zome calls:</td>
                             <td><ul>
-                                <li v-for="call in dump.queued_calls" class="zome-call">
+                                <li v-for="call in stateDumps[instance_id].queued_calls" class="zome-call">
                                 {{`${call.zome_name}.${call.fn_name}(${call.parameters})`}}
                                 </li></ul>
                             </td>
@@ -238,7 +238,7 @@
                         <tr>
                             <td>Running zome calls:</td>
                             <td><ul>
-                                <li v-for="call in dump.running_calls" class="zome-call">
+                                <li v-for="call in stateDumps[instance_id].running_calls" class="zome-call">
                                 {{`${call[0].zome_name}.${call[0].fn_name}(${call[0].parameters})`}}
                                 <br>
                                 HDK calls: {{call[1]}}
@@ -247,7 +247,7 @@
                         <tr>
                             <td>Zome call results:</td>
                             <td><ul>
-                                <li v-for="call in dump.call_results" class="zome-call">
+                                <li v-for="call in stateDumps[instance_id].call_results" class="zome-call">
                                 {{`${call[0].zome_name}.${call[0].fn_name}(${call[0].parameters}) => ${JSON.stringify(call[1])}`}}
                                 </li></ul>
                             </td>
@@ -262,9 +262,9 @@
                 </h3>
                 <table v-bind:id="sanitizeName(instance_id)+'network'" class="table collapse">
                     <tbody>
-                        <tr><td>Queries:</td><td>{{ dump.query_flows }}</td></tr>
-                        <tr><td>Validation Package Requests:</td><td>{{ dump.validation_package_flows }}</td></tr>
-                        <tr><td>Direct message sessions:</td><td>{{ dump.direct_message_flows }}</td></tr>
+                        <tr><td>Queries:</td><td>{{ stateDumps[instance_id].query_flows }}</td></tr>
+                        <tr><td>Validation Package Requests:</td><td>{{ stateDumps[instance_id].validation_package_flows }}</td></tr>
+                        <tr><td>Direct message sessions:</td><td>{{ stateDumps[instance_id].direct_message_flows }}</td></tr>
                     </tbody>
                 </table>
             </li>

--- a/views/debug_view.html
+++ b/views/debug_view.html
@@ -97,7 +97,7 @@
                     <v-data-table
                         caption="Source Chain"
                         :headers="chainHeaders"
-                    :items="dump.source_chain"
+                        :items="dump.source_chain"
                         :search="chainSearch"
                         show-expand
                         class="elevation-1"

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -1,11 +1,7 @@
 import { ipcRenderer } from 'electron'
-//import Vue from 'vue'
-//import path from 'path'
-//const vuetifyPluginPath = path.join(__dirname, 'plugins', 'vuetify')
-//import vuetify from '../plugins/vuetify'
 import Vue from 'vue'
 import VueChatScroll from 'vue-chat-scroll'
-import Vuetify, {VDataTable, VApp, VContainer} from 'vuetify/lib'
+import Vuetify, {VDataTable, VApp, VContainer, VChip, VToolbarTitle, VSpacer, VTextField} from 'vuetify/lib'
 import { Ripple } from 'vuetify/lib/directives'
 
 Vue.use(VueChatScroll)
@@ -13,7 +9,11 @@ Vue.use(Vuetify,  {
     components: {
       VApp,
       VDataTable,
-      VContainer
+      VContainer,
+      VChip,
+      VToolbarTitle, 
+      VSpacer, 
+      VTextField
     },
     directives: {
       Ripple,
@@ -33,16 +33,8 @@ Vue.use(Vuetify,  {
         },
       },
 })
-/*
-const App = {
-    template: '#app-template',
-    data: () => ({
-      //
-    })
-  }
-  */
 
- const vuetifyOptions = { theme: {dark:true}}
+const vuetifyOptions = { theme: {dark:true}}
 
 let configured = false
 
@@ -104,23 +96,7 @@ ipcRenderer.on('conductor-call-set', () => {
     }
 
     var app = new Vue({
-        vuetify: new Vuetify(vuetifyOptions)/*{
-          icons: {
-            iconfont: 'md',  // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4'
-          },
-          theme: {
-            dark: false,
-          },
-          themes: {
-            light: {
-              primary: "#4682b4",
-              secondary: "#b0bec5",
-              accent: "#8c9eff",
-              error: "#b71c1c",
-            },
-          }
-        })*/,
-        //render: h => h(App),
+        vuetify: new Vuetify(vuetifyOptions),
         data: {
           instances: [],  
           reduxActions: {},  
@@ -137,6 +113,7 @@ ipcRenderer.on('conductor-call-set', () => {
                 value: 'entry_type',
             },
             { text: 'Address', value: 'entry_address' },
+            { text: '', value: 'data-table-expand' },
             { text: 'Timestamp', value: 'timestamp' },
             { text: 'Provenances', value: 'provenances' },
           ],

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -117,7 +117,28 @@ ipcRenderer.on('conductor-call-set', () => {
             { text: 'Timestamp', value: 'timestamp' },
             { text: 'Provenances', value: 'provenances' },
           ],
+          heldHeaders: [
+            {
+                text: 'Entry Address',
+                align: 'left',
+                sortable: false,
+                value: 'address',
+            },
+            {
+                text: 'Type',
+                align: 'left',
+                sortable: false,
+                value: 'type',
+            },
+            {
+                text: 'Content',
+                align: 'left',
+                sortable: false,
+                value: 'content',
+            },
+          ],
           chainSearch: '',
+          heldSearch: '',
           updateStateDump: (instance_id) => {
               console.log(`Update state dump with: ${instance_id}`)
               call('debug/state_dump')({instance_id})

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -117,6 +117,33 @@ ipcRenderer.on('conductor-call-set', () => {
             { text: 'Timestamp', value: 'timestamp' },
             { text: 'Provenances', value: 'provenances' },
           ],
+          queueHeaders: [
+            {
+                text: 'Entry Address',
+                align: 'left',
+                sortable: false,
+                value: 'address',
+            },
+            { text: '', value: 'data-table-expand' },
+            {
+                text: 'Workflow Type',
+                align: 'left',
+                sortable: false,
+                value: 'type',
+            },
+            {
+                text: 'Delay',
+                align: 'left',
+                sortable: false,
+                value: 'content',
+            },
+            {
+                text: 'Dependencies',
+                align: 'left',
+                sortable: false,
+                value: 'content',
+            },
+          ],
           heldHeaders: [
             {
                 text: 'Entry Address',
@@ -138,6 +165,7 @@ ipcRenderer.on('conductor-call-set', () => {
             },
           ],
           chainSearch: '',
+          queueSearch: '',
           heldSearch: '',
           updateStateDump: (instance_id) => {
               console.log(`Update state dump with: ${instance_id}`)

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -53,20 +53,12 @@ ipcRenderer.on('conductor-call-set', () => {
               app.updateSourceChain(instance_id)
               app.updateHeldAspects(instance_id)
               app.updateValidationQueues(instance_id)
-              Vue.set(app.updateActions, instance_id, false)
-              Vue.set(app.refreshDump, instance_id, false)
-              app.instances.push(instance_id)
+              if(!app.instances.includes(instance_id)) {
+                app.instances.push(instance_id)
+              }
             })
         })
     }
-
-    setInterval(() => {
-        for(let instance of app.instances) {
-            if(app.refreshDump[instance]) {
-                app.updateStateDump(instance)
-            }
-        }
-    }, 1500)
 
     const fetch_cas = async (address, instance_id) => {
         return await call('debug/fetch_cas')({instance_id, address})
@@ -107,9 +99,7 @@ ipcRenderer.on('conductor-call-set', () => {
           sourceChains: {},
           holdingMaps: {},
           validationQueues: {},
-          refreshDump: {},
           contents: {},
-          updateActions: {},
           stats: {},
           chainHeaders: [
             {
@@ -267,8 +257,10 @@ ipcRenderer.on('conductor-call-set', () => {
             return
         }
         if(signal.signal_type == "Stats") {
-            
-            app.stats = signal.instance_stats
+            if(JSON.stringify(signal.instance_stats) != JSON.stringify(app.stats)) {
+                console.log("updating stats")
+                app.stats = signal.instance_stats
+            }
             return
         }
 
@@ -301,9 +293,7 @@ ipcRenderer.on('conductor-call-set', () => {
         if(!app.reduxActions[instance_id]) {
             Vue.set(app.reduxActions, instance_id, [])
         }
-        if(!app.updateActions[instance_id]) {
-            return
-        }
+
         if(!signal.action) {
             console.log("Got strange trace signal without 'action' property:", params)
             return

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -249,7 +249,7 @@ ipcRenderer.on('conductor-call-set', () => {
 
         let actions = app.reduxActions[instance_id]
         actions.push(signal.action)
-        while(actions.lenght > 100) {
+        while(actions.length > 100) {
             actions.shift()
         }
     })

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -251,19 +251,20 @@ ipcRenderer.on('conductor-call-set', () => {
     }).$mount('#app')
 
     ipcRenderer.on('hc-signal', (event, params) => {
-        let { signal, instance_id } = params
-        if(!signal) {
-            console.log("Got strange signal without 'signal' property:", params)
-            return
-        }
-        if(signal.signal_type == "Stats") {
-            if(JSON.stringify(signal.instance_stats) != JSON.stringify(app.stats)) {
+        let { signal, instance_id, instance_stats } = params
+        if(instance_stats) {
+            if(JSON.stringify(instance_stats) != JSON.stringify(app.stats)) {
                 console.log("updating stats")
-                app.stats = signal.instance_stats
+                app.stats = instance_stats
             }
             return
         }
 
+        if(!signal) {
+            console.log("Got strange signal without 'signal' property:", params)
+            return
+        }
+        
         if(!instance_id) {
             console.log("Got strange signal without 'instance_id' property:", params)
             return

--- a/views/debug_view.js
+++ b/views/debug_view.js
@@ -1,0 +1,234 @@
+import { ipcRenderer } from 'electron'
+//import Vue from 'vue'
+//import path from 'path'
+//const vuetifyPluginPath = path.join(__dirname, 'plugins', 'vuetify')
+//import vuetify from '../plugins/vuetify'
+import Vue from 'vue'
+import VueChatScroll from 'vue-chat-scroll'
+import Vuetify, {VDataTable, VApp, VContainer} from 'vuetify/lib'
+import { Ripple } from 'vuetify/lib/directives'
+
+Vue.use(VueChatScroll)
+Vue.use(Vuetify,  {
+    components: {
+      VApp,
+      VDataTable,
+      VContainer
+    },
+    directives: {
+      Ripple,
+    },
+      icons: {
+        iconfont: 'md',  // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4'
+      },
+      theme: {
+        dark: true,
+      },
+      themes: {
+        light: {
+          primary: "#4682b4",
+          secondary: "#b0bec5",
+          accent: "#8c9eff",
+          error: "#b71c1c",
+        },
+      },
+})
+/*
+const App = {
+    template: '#app-template',
+    data: () => ({
+      //
+    })
+  }
+  */
+
+ const vuetifyOptions = { theme: {dark:true}}
+
+let configured = false
+
+ipcRenderer.on('conductor-call-set', () => {
+    if(configured) return
+    configured = true
+
+    const remote = require('electron').remote
+    const happUiController = remote.getGlobal('holoscape').happUiController
+    const call = remote.getGlobal('conductor_call')
+
+    const refresh = () => {
+      call('debug/running_instances')().then((instances)=>{
+          instances.map((instance_id) => {
+              app.updateStateDump(instance_id)
+              Vue.set(app.updateActions, instance_id, false)
+              Vue.set(app.refreshDump, instance_id, false)
+              app.instances.push(instance_id)
+            })
+        })
+    }
+
+    setInterval(() => {
+        for(let instance of app.instances) {
+            if(app.refreshDump[instance]) {
+                app.updateStateDump(instance)
+            }
+        }
+    }, 1500)
+
+    const fetch_cas = async (address, instance_id) => {
+        return await call('debug/fetch_cas')({instance_id, address})
+    }
+
+    const updateContent = async (address, instance_id) => {
+        Vue.set(app.contents, address, await fetch_cas(address, instance_id))
+    }
+
+    const syntaxHighlight = (json) => {
+        if (typeof json != 'string') {
+            json = JSON.stringify(json, undefined, 2);
+        }
+        json = json.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
+            var cls = 'number';
+            if (/^"/.test(match)) {
+                if (/:$/.test(match)) {
+                    cls = 'key';
+                } else {
+                    cls = 'string';
+                }
+            } else if (/true|false/.test(match)) {
+                cls = 'boolean';
+            } else if (/null/.test(match)) {
+                cls = 'null';
+            }
+            return '<span class="' + cls + '">' + match + '</span>';
+        });
+    }
+
+    var app = new Vue({
+        vuetify: new Vuetify(vuetifyOptions)/*{
+          icons: {
+            iconfont: 'md',  // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4'
+          },
+          theme: {
+            dark: false,
+          },
+          themes: {
+            light: {
+              primary: "#4682b4",
+              secondary: "#b0bec5",
+              accent: "#8c9eff",
+              error: "#b71c1c",
+            },
+          }
+        })*/,
+        //render: h => h(App),
+        data: {
+          instances: [],  
+          reduxActions: {},  
+          stateDumps: {},
+          refreshDump: {},
+          contents: {},
+          updateActions: {},
+          stats: {},
+          chainHeaders: [
+            {
+                text: 'Type',
+                align: 'left',
+                sortable: false,
+                value: 'entry_type',
+            },
+            { text: 'Address', value: 'entry_address' },
+            { text: 'Timestamp', value: 'timestamp' },
+            { text: 'Provenances', value: 'provenances' },
+          ],
+          chainSearch: '',
+          updateStateDump: (instance_id) => {
+              console.log(`Update state dump with: ${instance_id}`)
+              call('debug/state_dump')({instance_id})
+                .then((dump) => {
+                    console.log("Got state dump: ", dump)
+                    Vue.set(app.stateDumps, instance_id, dump)
+                })
+                .catch((error) => {
+                    console.log("Error getting dump:", error)
+                })
+          },
+          refresh: refresh,
+          fetch_cas,
+          updateContent,
+          syntaxHighlight,
+          actionTypeToBadge: (actionType) => {
+              switch(actionType) {
+                  case "SignalZomeFunctionCall": return "info"
+                  case "ReturnZomeFunctionResult": return "info"
+                  case "ReturnValidationPackage": return "secondary"
+                  case "ReturnValidationResult": return "secondary"
+                  case "Commit": return "success"
+                  case "Publish": return "success"
+                  case "HoldAspect": return "danger"
+                  case "Query": return "light"
+                  case "RespondQuery": return "dark"
+                  case "HandleQuery": return "light"
+                  case "QueryTimeout": return "warning"
+                  default: return "primary"
+              }
+          },
+          sanitizeName: (name) => {
+            name = name
+                .split('_').join('-')
+                .split(' ').join('-')
+                .split('&').join('-')
+                .split('#').join('-')
+                .split('.').join('-')
+                .split('$').join('-')
+                .toLowerCase()
+            return name
+          },
+          showAction: (action) => {
+              window.alert(JSON.stringify(action))
+          }
+        }
+    }).$mount('#app')
+
+    ipcRenderer.on('hc-signal', (event, params) => {
+        let { signal, instance_id } = params
+        if(!signal) {
+            console.log("Got strange signal without 'signal' property:", params)
+            return
+        }
+        if(signal.signal_type == "Stats") {
+            
+            app.stats = signal.instance_stats
+            return
+        }
+
+        if(!instance_id) {
+            console.log("Got strange signal without 'instance_id' property:", params)
+            return
+        }
+
+        if(signal.signal_type != "Trace") {
+            // Ignoring non-trace signals
+            return
+        }
+        if(!app.reduxActions[instance_id]) {
+            Vue.set(app.reduxActions, instance_id, [])
+        }
+        if(!app.updateActions[instance_id]) {
+            return
+        }
+        if(!signal.action) {
+            console.log("Got strange trace signal without 'action' property:", params)
+            return
+        }
+
+        let actions = app.reduxActions[instance_id]
+        actions.push(signal.action)
+        while(actions.lenght > 100) {
+            actions.shift()
+        }
+    })
+
+    refresh()
+    window.app = app
+    window.call = call
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const VueLoaderPlugin = require('vue-loader/lib/plugin')
+const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
+
+module.exports = {
+  entry: './views/debug_view.js',
+  output: {
+    filename: 'debug_view.dist.js',
+    path: path.resolve(__dirname, 'views'),
+  },
+  target: "electron-renderer",
+  module: {
+    rules: [
+        {
+          test: /\.s(c|a)ss$/,
+          use: [
+            'vue-style-loader',
+            'css-loader',
+            {
+              loader: 'sass-loader',
+              // Requires sass-loader@^7.0.0
+              options: {
+                implementation: require('sass'),
+                fiber: require('fibers'),
+                indentedSyntax: true // optional
+              },
+              // Requires sass-loader@^8.0.0
+              options: {
+                implementation: require('sass'),
+                sassOptions: {
+                  fiber: require('fibers'),
+                  indentedSyntax: true // optional
+                },
+              },
+            },
+          ],
+        },
+        {
+            test: /\.vue$/,
+            loader: 'vue-loader'
+          }
+    ],
+  },
+  plugins: [
+    new VueLoaderPlugin(),
+    new VuetifyLoaderPlugin()
+  ],
+  resolve: {
+    alias: {
+      'vue$': 'vue/dist/vue.esm.js'
+    }
+  },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,4 +50,5 @@ module.exports = {
       'vue$': 'vue/dist/vue.esm.js'
     }
   },
+  devtool: 'eval-source-map'
 };


### PR DESCRIPTION
# Vuetify components and faster state dumps
This adds [Vuetify](https://vuetifyjs.com) and uses its fast and customizable data tables in the debug view. This easily enables searching for entry hashes or types in source chain as well as the holding map.

![Screenshot from 2019-12-10 01-14-08](https://user-images.githubusercontent.com/311749/70484120-12025180-1aeb-11ea-939c-54ff1efcb7d6.png)

This already helped a lot with the rendering performance since the data tables sport pagination.

But in order to make the refresh really fast I had to split state dumps into sparate portions that get updated independently. This is based on these changes in holochain-rust: https://github.com/holochain/holochain-rust/pull/1954

With that, the debug view is fast enough to enable automatic refresh based on trace actions - we know that we only need to get the source chain after a `commit` action, and only the holding map after a `HoldApsect` action, etc.

Also shows instance stats (held entries, pending validations, running calls) in header:
![Screenshot from 2019-12-10 01-12-32](https://user-images.githubusercontent.com/311749/70484116-10388e00-1aeb-11ea-8875-0bf6c8362896.png)

