### PR TITLE
a little bit of README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ cd holoscape
 # Run all commands for this project while cd'd in this directory
 ```
 
-Holoscape needs both binaries ouf the [holochain-rust](https://github.com/holochain/holochain-rust) repository: `hc` and `holochain`.
+Holoscape needs both binaries out of the [holochain-rust](https://github.com/holochain/holochain-rust) repository: `hc` and `holochain`.
 
 Depending on the OS, it expects to find either `hc-linux` and `holochain-linux` or `hc-darwin` and `holochain-darwin` in the application directory (the root of the repository during development).
 
@@ -53,13 +53,14 @@ To flush all holoscape data with the nix shell:
 
 ```shell
 $ nix-shell https://github.com/holochain/holoscape/archive/develop.tar.gz --run holoscape-flush
+```
 
 ## Run for development
 ```
 npm start
 ```
 
-### Personas
+## Personas
 Persona's allow you to run multiple instances of Holoscape.  This is useful for a few reasons:
 - Networks: Because each Holoscape instance is configured to communicate over one network, you can use this run instances on different networks.
 - Testing: this makes it easy to spin up multiple nodes on the same network for testing purposes.

--- a/views/splash.html
+++ b/views/splash.html
@@ -126,7 +126,7 @@
   <pre>  $ nix-shell https://holochain.love
     $ cp `which holochain` holochain-linux
     $ cp `which hc` hc-linux</pre>
-                <p>(or <span class='code'>holochain-darwin</span> for macOS - Windows is currently not support but will follow soon)</p>
+                <p>(or <span class='code'>holochain-darwin</span> for macOS - Windows is currently not supported but will follow soon)</p>
                 <p>See <a href="#" v-on:click="openExternal('https://github.com/holochain/holoscape/blob/master/README.md')">README</a></p>
               </div>
             </div>


### PR DESCRIPTION
fixed a typo (ouf -> out of).
pulled "##Run for development" out of code block as likely expected. 
made personas heading consistent with the others.
"Windows is not currently support" (+ed)