### PR TITLE
HTML "_blank" links open in default system browser, fix issue #54

### DIFF
--- a/happ-ui-controller.js
+++ b/happ-ui-controller.js
@@ -1,4 +1,4 @@
-const { BrowserView, dialog, protocol, session, ipcMain } = require('electron')
+const { BrowserView, dialog, protocol, session, ipcMain, shell } = require('electron')
 const { ncp } = require('ncp')
 const fs = require('fs')
 const path = require('path')
@@ -271,6 +271,13 @@ class HappUiController {
         console.log('Created view. Loading', windowURL)
 
         view.webContents.loadURL(windowURL)
+
+        // Open <a href='' target='_blank'> with default system browser
+        view.webContents.on("new-window", function (event, url) {
+            event.preventDefault()
+            shell.openExternal(url)
+        })
+                
         //setupWindowDevProduction(view)
         let holoscape = this.holoscape
         view.on('close', (event) => {

--- a/views/legacy_install_bundle_view.html
+++ b/views/legacy_install_bundle_view.html
@@ -313,7 +313,6 @@
                 installed_instances: [],
                 installed_dnas: [],
                 installed_bridges: [],
-                used_ports: [],
                 happ_index: [],
                 selected_happ: undefined,
             },
@@ -631,15 +630,17 @@
             console.log('Bridge added')
         }
 
-        const nextMinPort = () => {
-            if(app.used_ports.length > 0) {
-                app.used_ports.sort()
-                return app.used_ports[app.used_ports.length -1] + 1
+        const nextMinPort = async () => {
+            const interfaces = await call('admin/interface/list')()
+            if (Array.isArray(interfaces) && interfaces.length > 0) {
+                const ports = []
+                interfaces.forEach(interface => ports.push(interface.driver.port))
+                return Math.max(...ports) + 1
             } else {
                 return 10000
             }
         }
-
+        
         const installUi = async (ui) => {
             console.log(JSON.stringify(ui))
             let extractedPath = temp.path()
@@ -658,8 +659,8 @@
             let id = `${ui.name}-interface`
             let type = 'websocket'
             let admin = app.installAsAdmin
-            let port = await getPort({port: getPort.makeRange(nextMinPort(), 31000)})
-            app.used_ports.push(port)
+            let minPort = await nextMinPort()
+            let port = await getPort({port: getPort.makeRange(minPort, 31000)})
             await call('admin/interface/add')({id,admin,type,port})
 
             for(ref of ui.instance_references) {


### PR DESCRIPTION
HTML links using the "_blank" target perhaps should open in system default browser instead of inside the Electron app? This short addition fixes that.